### PR TITLE
Hp 2693 upgrade phpunit to v12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name":              "ocramius/code-generator-utils",
+    "name":              "hiqdev/code-generator-utils",
     "description":       "A set of code generator utilities built on top of PHP-Parsers that ease its use when combined with Reflection",
     "type":              "library",
     "license":           "MIT",
-    "homepage":          "https://github.com/Ocramius/CodeGenerationUtils",
+    "homepage":          "https://github.com/hiqdev/CodeGenerationUtils",
     "keywords":          [
         "reflection",
         "code generation",

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
         }
     ],
     "require": {
-        "php":                       "~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php":                       "^8.3",
         "nikic/php-parser":          "^5.6.1"
     },
     "require-dev": {
         "doctrine/coding-standard":               "^12.0.0",
-        "phpunit/phpunit":                        "^11.5.7",
+        "phpunit/phpunit":                        "^12.0",
         "psalm/plugin-phpunit":                   "^0.19.2",
         "roave/infection-static-analysis-plugin": "^1.36.0",
         "vimeo/psalm":                            "^6.5.1"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php":                       "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "nikic/php-parser":          "^v5.4.0"
+        "nikic/php-parser":          "^5.6.1"
     },
     "require-dev": {
         "doctrine/coding-standard":               "^12.0.0",

--- a/src/CodeGenerationUtils/Visitor/ClassRenamerVisitor.php
+++ b/src/CodeGenerationUtils/Visitor/ClassRenamerVisitor.php
@@ -100,7 +100,7 @@ class ClassRenamerVisitor extends NodeVisitorAbstract
 
                 assert($namespaceName !== null);
 
-                $namespace->name = new Name\FullyQualified($newParts);
+                $namespace->name = new Node\Name($newParts);
 
                 return $namespace;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Project metadata updated (package name and homepage) and platform requirement raised to PHP ^8.3.
  * Updated parser dependency to ^5.6.1 and test tooling to PHPUnit ^12.0.
* Refactor
  * Internal namespace representation adjusted to align with newer parser behavior; no public API changes.
* Reliability
  * Minor internal improvements to maintain consistent code generation across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->